### PR TITLE
vrf: add VrfInOut funcs, VrfOutput type

### DIFF
--- a/vrf.go
+++ b/vrf.go
@@ -26,7 +26,7 @@ func (io *VrfInOut) Output() *VrfOutput {
 	}
 }
 
-// EncodeOutput returns the encoding of the input and output concatenated
+// EncodeOutput returns the 64-byte encoding of the input and output concatenated
 func (io *VrfInOut) Encode() []byte {
 	outbytes := [32]byte{}
 	copy(outbytes[:], io.output.Encode([]byte{}))
@@ -58,6 +58,15 @@ func (out *VrfOutput) Encode() [32]byte {
 	outbytes := [32]byte{}
 	copy(outbytes[:], out.output.Encode([]byte{}))
 	return outbytes
+}
+
+// Encode returns a 64-byte encoded VrfProof
+func (p *VrfProof) Encode() []byte {
+	cbytes := [32]byte{}
+	copy(cbytes[:], p.c.Encode([]byte{}))
+	sbytes := [32]byte{}
+	copy(sbytes[:], p.s.Encode([]byte{}))
+	return append(cbytes[:], sbytes[:]...)
 }
 
 // VrfSign returns a vrf output and proof given a secret key and transcript.

--- a/vrf.go
+++ b/vrf.go
@@ -26,11 +26,13 @@ func (io *VrfInOut) Output() *VrfOutput {
 	}
 }
 
-// EncodeOutput returns the 32-byte encoding of the output
-func (io *VrfInOut) EncodeOutput() [32]byte {
+// EncodeOutput returns the encoding of the input and output concatenated
+func (io *VrfInOut) Encode() []byte {
 	outbytes := [32]byte{}
 	copy(outbytes[:], io.output.Encode([]byte{}))
-	return outbytes
+	inbytes := [32]byte{}
+	copy(inbytes[:], io.input.Encode([]byte{}))
+	return append(inbytes[:], outbytes[:]...)
 }
 
 // NewOutput creates a new VRF output from a 64-byte element
@@ -46,9 +48,16 @@ func NewOutput(in [32]byte) *VrfOutput {
 func (out *VrfOutput) AttachInput(pub *PublicKey, t *merlin.Transcript) *VrfInOut {
 	input := pub.vrfHash(t)
 	return &VrfInOut{
-		input: input,
+		input:  input,
 		output: out.output,
 	}
+}
+
+// Encode returns the 32-byte encoding of the output
+func (out *VrfOutput) Encode() [32]byte {
+	outbytes := [32]byte{}
+	copy(outbytes[:], out.output.Encode([]byte{}))
+	return outbytes
 }
 
 // VrfSign returns a vrf output and proof given a secret key and transcript.

--- a/vrf_test.go
+++ b/vrf_test.go
@@ -20,7 +20,7 @@ func TestInputAndOutput(t *testing.T) {
 	inout, proof, err := priv.VrfSign(signTranscript)
 	if err != nil {
 		t.Fatal(err)
-	}	
+	}
 
 	outslice := inout.output.Encode([]byte{})
 	outbytes := [32]byte{}

--- a/vrf_test.go
+++ b/vrf_test.go
@@ -7,6 +7,37 @@ import (
 	r255 "github.com/gtank/ristretto255"
 )
 
+func TestInputAndOutput(t *testing.T) {
+	signTranscript := merlin.NewTranscript("vrf-test")
+	inoutTranscript := merlin.NewTranscript("vrf-test")
+	verifyTranscript := merlin.NewTranscript("vrf-test")
+
+	priv, pub, err := GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inout, proof, err := priv.VrfSign(signTranscript)
+	if err != nil {
+		t.Fatal(err)
+	}	
+
+	outslice := inout.output.Encode([]byte{})
+	outbytes := [32]byte{}
+	copy(outbytes[:], outslice)
+	out := NewOutput(outbytes)
+	inout2 := out.AttachInput(pub, inoutTranscript)
+
+	ok, err := pub.VrfVerify(verifyTranscript, inout2, proof)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ok {
+		t.Fatal("did not verify vrf")
+	}
+}
+
 func TestVRFSignAndVerify(t *testing.T) {
 	signTranscript := merlin.NewTranscript("vrf-test")
 	verifyTranscript := merlin.NewTranscript("vrf-test")


### PR DESCRIPTION
add helper functions for VrfInOut and create VrfOutput, since in BABE, we only use the VrfOutput (need to reconstruct input)