### PR TITLE
fix: address issues from Trail of Bits audit

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -13,6 +13,10 @@ func VerifyBatch(transcripts []*merlin.Transcript, signatures []*Signature, pubk
 		return false, errors.New("the number of transcripts, signatures, and public keys must be equal")
 	}
 
+	if len(transcripts) == 0 {
+		return true, nil
+	}
+
 	var err error
 	zero := r255.NewElement().Zero()
 	zs := make([]*r255.Scalar, len(transcripts))
@@ -27,6 +31,10 @@ func VerifyBatch(transcripts []*merlin.Transcript, signatures []*Signature, pubk
 	hs := make([]*r255.Scalar, len(transcripts))
 	s := make([]r255.Scalar, len(transcripts))
 	for i, t := range transcripts {
+		if t == nil {
+			return false, errors.New("transcript provided was nil")
+		}
+
 		t.AppendMessage([]byte("proto-name"), []byte("Schnorr-sig"))
 		pubc := pubkeys[i].Encode()
 		t.AppendMessage([]byte("sign:pk"), pubc[:])
@@ -41,6 +49,10 @@ func VerifyBatch(transcripts []*merlin.Transcript, signatures []*Signature, pubk
 	// compute ∑ z_i P_i H(R_i || P_i || m_i)
 	ps := make([]*r255.Element, len(pubkeys))
 	for i, p := range pubkeys {
+		if p == nil {
+			return false, errors.New("public key provided was nil")
+		}
+
 		ps[i] = r255.NewElement().ScalarMult(zs[i], p.key)
 	}
 
@@ -50,6 +62,10 @@ func VerifyBatch(transcripts []*merlin.Transcript, signatures []*Signature, pubk
 	ss := r255.NewScalar()
 	rs := r255.NewElement()
 	for i, s := range signatures {
+		if s == nil {
+			return false, errors.New("signature provided was nil")
+		}
+
 		zsi := r255.NewScalar().Multiply(s.s, zs[i])
 		ss = r255.NewScalar().Add(ss, zsi)
 		zri := r255.NewElement().ScalarMult(zs[i], s.r)

--- a/derive.go
+++ b/derive.go
@@ -230,7 +230,7 @@ func (pk *PublicKey) DeriveKey(t *merlin.Transcript, cc [ChainCodeLength]byte) (
 // DeriveScalarAndChaincode derives a new scalar and chain code from an existing public key and chain code
 func (pk *PublicKey) DeriveScalarAndChaincode(t *merlin.Transcript, cc [ChainCodeLength]byte) (*r255.Scalar, [ChainCodeLength]byte, error) {
 	if t == nil {
-		return nil, [32]byte{}, errors.New("transcript provided is nil")
+		return nil, [ChainCodeLength]byte{}, errors.New("transcript provided is nil")
 	}
 
 	t.AppendMessage([]byte("chain-code"), cc[:])

--- a/derive_test.go
+++ b/derive_test.go
@@ -50,7 +50,8 @@ func TestDerivePublicAndPrivateMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// confirm that key derived from public path can verify signature derived from private path
-	ok := dpub.key.(*PublicKey).Verify(sig, verifyTranscript)
+	ok, err := dpub.key.(*PublicKey).Verify(sig, verifyTranscript)
+	require.NoError(t, err)
 	require.True(t, ok)
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -52,7 +52,12 @@ func NewRandomScalar() (*r255.Scalar, error) {
 	}
 
 	ss := r255.NewScalar()
-	return ss.FromUniformBytes(s[:]), nil
+	sc := ss.FromUniformBytes(s[:])
+	if sc.Equal(r255.NewScalar()) == 1 {
+		return nil, errors.New("scalar generated was zero")
+	}
+
+	return sc, nil
 }
 
 // ScalarFromBytes returns a ristretto scalar from the input bytes

--- a/keys.go
+++ b/keys.go
@@ -3,6 +3,7 @@ package schnorrkel
 import (
 	"crypto/rand"
 	"crypto/sha512"
+	"errors"
 
 	"github.com/gtank/merlin"
 	r255 "github.com/gtank/ristretto255"
@@ -17,6 +18,11 @@ const (
 
 	// PublicKeySize is the length in bytes of a PublicKey
 	PublicKeySize = 32
+)
+
+var (
+	publicKeyAtInfinity    = r255.NewElement().ScalarBaseMult(r255.NewScalar())
+	errPublicKeyAtInfinity = errors.New("public key is the point at infinity")
 )
 
 // MiniSecretKey is a secret scalar

--- a/sign.go
+++ b/sign.go
@@ -104,7 +104,15 @@ func (sk *SecretKey) Sign(t *merlin.Transcript) (*Signature, error) {
 // 1. k = scalar(transcript.extract_bytes())
 // 2. R' = -ky + gs
 // 3. return R' == R
-func (p *PublicKey) Verify(s *Signature, t *merlin.Transcript) bool {
+func (p *PublicKey) Verify(s *Signature, t *merlin.Transcript) (bool, error) {
+	if s == nil {
+		return false, errors.New("signature provided is nil")
+	}
+
+	if t == nil {
+		return false, errors.New("transcript provided is nil")
+	}
+
 	t.AppendMessage([]byte("proto-name"), []byte("Schnorr-sig"))
 	pubc := p.Encode()
 	t.AppendMessage([]byte("sign:pk"), pubc[:])
@@ -119,7 +127,7 @@ func (p *PublicKey) Verify(s *Signature, t *merlin.Transcript) bool {
 	ky := r255.NewElement().ScalarMult(k, p.key)
 	Rp = Rp.Subtract(Rp, ky)
 
-	return Rp.Equal(s.r) == 1
+	return Rp.Equal(s.r) == 1, nil
 }
 
 // Decode sets a Signature from bytes

--- a/sign.go
+++ b/sign.go
@@ -113,6 +113,10 @@ func (p *PublicKey) Verify(s *Signature, t *merlin.Transcript) (bool, error) {
 		return false, errors.New("transcript provided is nil")
 	}
 
+	if p.key.Equal(publicKeyAtInfinity) == 1 {
+		return false, errPublicKeyAtInfinity
+	}
+
 	t.AppendMessage([]byte("proto-name"), []byte("Schnorr-sig"))
 	pubc := p.Encode()
 	t.AppendMessage([]byte("sign:pk"), pubc[:])

--- a/sign_test.go
+++ b/sign_test.go
@@ -2,6 +2,7 @@ package schnorrkel
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -172,4 +173,19 @@ func TestVerify_rust(t *testing.T) {
 	ok, err := pub.Verify(sig, transcript)
 	require.NoError(t, err)
 	require.True(t, ok)
+}
+
+func TestVerify_PublicKeyAtInfinity(t *testing.T) {
+	transcript := merlin.NewTranscript("hello")
+	priv := SecretKey{}
+	pub, err := priv.Public()
+	require.NoError(t, err)
+	require.Equal(t, pub.key, publicKeyAtInfinity)
+
+	sig, err := priv.Sign(transcript)
+	require.NoError(t, err)
+
+	transcript2 := merlin.NewTranscript("hello")
+	_, err = pub.Verify(sig, transcript2)
+	require.True(t, errors.Is(err, errPublicKeyAtInfinity))
 }

--- a/sign_test.go
+++ b/sign_test.go
@@ -26,7 +26,11 @@ func ExampleSecretKey_Sign() {
 		panic(err)
 	}
 
-	ok := pub.Verify(sig, verifyTranscript)
+	ok, err := pub.Verify(sig, verifyTranscript)
+	if err != nil {
+		panic(err)
+	}
+
 	if !ok {
 		fmt.Println("failed to verify signature")
 		return
@@ -49,7 +53,11 @@ func ExamplePublicKey_Verify() {
 
 	msg := []byte("this is a message")
 	transcript := NewSigningContext(SigningContext, msg)
-	ok := pub.Verify(sig, transcript)
+	ok, err := pub.Verify(sig, transcript)
+	if err != nil {
+		panic(err)
+	}
+
 	if !ok {
 		fmt.Println("failed to verify signature")
 		return
@@ -87,7 +95,8 @@ func TestSignAndVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	transcript2 := merlin.NewTranscript("hello")
-	ok := pub.Verify(sig, transcript2)
+	ok, err := pub.Verify(sig, transcript2)
+	require.NoError(t, err)
 	require.True(t, ok)
 }
 
@@ -100,11 +109,13 @@ func TestVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	transcript2 := merlin.NewTranscript("hello")
-	ok := pub.Verify(sig, transcript2)
+	ok, err := pub.Verify(sig, transcript2)
+	require.NoError(t, err)
 	require.True(t, ok)
 
 	transcript3 := merlin.NewTranscript("hello")
-	ok = pub.Verify(sig, transcript3)
+	ok, err = pub.Verify(sig, transcript3)
+	require.NoError(t, err)
 	require.True(t, ok)
 }
 
@@ -158,6 +169,7 @@ func TestVerify_rust(t *testing.T) {
 	require.NoError(t, err)
 
 	transcript := NewSigningContext(SigningContext, msg)
-	ok := pub.Verify(sig, transcript)
+	ok, err := pub.Verify(sig, transcript)
+	require.NoError(t, err)
 	require.True(t, ok)
 }

--- a/vrf.go
+++ b/vrf.go
@@ -250,6 +250,10 @@ func (pk *PublicKey) VrfVerify(t *merlin.Transcript, out *VrfOutput, proof *VrfP
 		return false, errors.New("proof provided is nil")
 	}
 
+	if pk.key.Equal(publicKeyAtInfinity) == 1 {
+		return false, errPublicKeyAtInfinity
+	}
+
 	inout, err := out.AttachInput(pk, t)
 	if err != nil {
 		return false, err

--- a/vrf.go
+++ b/vrf.go
@@ -81,12 +81,20 @@ func NewOutput(in [32]byte) (*VrfOutput, error) {
 
 // AttachInput returns a VrfInOut pair from an output
 // https://github.com/w3f/schnorrkel/blob/master/src/vrf.rs#L249
-func (out *VrfOutput) AttachInput(pub *PublicKey, t *merlin.Transcript) *VrfInOut {
+func (out *VrfOutput) AttachInput(pub *PublicKey, t *merlin.Transcript) (*VrfInOut, error) {
+	if pub == nil {
+		return nil, errors.New("public key provided is nil")
+	}
+
+	if t == nil {
+		return nil, errors.New("transcript provided is nil")
+	}
+
 	input := pub.vrfHash(t)
 	return &VrfInOut{
 		input:  input,
 		output: out.output,
-	}
+	}, nil
 }
 
 // Encode returns the 32-byte encoding of the output
@@ -140,6 +148,10 @@ func (p *VrfProof) Decode(in [64]byte) error {
 
 // VrfSign returns a vrf output and proof given a secret key and transcript.
 func (sk *SecretKey) VrfSign(t *merlin.Transcript) (*VrfInOut, *VrfProof, error) {
+	if t == nil {
+		return nil, nil, errors.New("transcript provided is nil")
+	}
+
 	p, err := sk.vrfCreateHash(t)
 	if err != nil {
 		return nil, nil, err
@@ -226,7 +238,23 @@ func (sk *SecretKey) vrfCreateHash(t *merlin.Transcript) (*VrfInOut, error) {
 
 // VrfVerify verifies that the proof and output created are valid given the public key and transcript.
 func (pk *PublicKey) VrfVerify(t *merlin.Transcript, out *VrfOutput, proof *VrfProof) (bool, error) {
-	inout := out.AttachInput(pk, t)
+	if t == nil {
+		return false, errors.New("transcript provided is nil")
+	}
+
+	if out == nil {
+		return false, errors.New("output provided is nil")
+	}
+
+	if proof == nil {
+		return false, errors.New("proof provided is nil")
+	}
+
+	inout, err := out.AttachInput(pk, t)
+	if err != nil {
+		return false, err
+	}
+
 	t0 := merlin.NewTranscript("VRF")
 	return pk.dleqVerify(t0, inout, proof)
 }

--- a/vrf.go
+++ b/vrf.go
@@ -5,6 +5,9 @@ import (
 	r255 "github.com/gtank/ristretto255"
 )
 
+// MAX_VRF_BYTES is the maximum bytes that can be extracted from the VRF via MakeBytes
+const MAX_VRF_BYTES = 64
+
 var kusamaVRF bool = true
 
 type VrfInOut struct {
@@ -44,8 +47,12 @@ func (io *VrfInOut) Encode() []byte {
 
 // MakeBytes returns raw bytes output from the VRF
 // It returns a byte slice of the given size
-// see https://github.com/w3f/schnorrkel/blob/master/src/vrf.rs#L334
-func (io *VrfInOut) MakeBytes(size int, context []byte) []byte {
+// https://github.com/w3f/schnorrkel/blob/master/src/vrf.rs#L343
+func (io *VrfInOut) MakeBytes(size int, context []byte) ([]byte, error) {
+	if size <= 0 || size > MAX_VRF_BYTES {
+		return nil, errors.New("invalid size parameter")
+	}
+
 	t := merlin.NewTranscript("VRFResult")
 	t.AppendMessage([]byte(""), context)
 	io.commit(t)

--- a/vrf.go
+++ b/vrf.go
@@ -1,6 +1,8 @@
 package schnorrkel
 
 import (
+	"errors"
+
 	"github.com/gtank/merlin"
 	r255 "github.com/gtank/ristretto255"
 )
@@ -56,7 +58,7 @@ func (io *VrfInOut) MakeBytes(size int, context []byte) ([]byte, error) {
 	t := merlin.NewTranscript("VRFResult")
 	t.AppendMessage([]byte(""), context)
 	io.commit(t)
-	return t.ExtractBytes([]byte(""), size)
+	return t.ExtractBytes([]byte(""), size), nil
 }
 
 func (io *VrfInOut) commit(t *merlin.Transcript) {

--- a/vrf_test.go
+++ b/vrf_test.go
@@ -1,6 +1,7 @@
 package schnorrkel
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -233,4 +234,19 @@ func TestVrfVerify_NotKusama(t *testing.T) {
 	bytes, err := inout.MakeBytes(16, []byte("substrate-babe-vrf"))
 	require.NoError(t, err)
 	require.Equal(t, make_bytes_16_expected, bytes)
+}
+
+func TestVRFVerify_PublicKeyAtInfinity(t *testing.T) {
+	signTranscript := merlin.NewTranscript("vrf-test")
+	verifyTranscript := merlin.NewTranscript("vrf-test")
+
+	priv := SecretKey{}
+	pub, err := priv.Public()
+	require.NoError(t, err)
+	require.Equal(t, pub.key, publicKeyAtInfinity)
+	inout, proof, err := priv.VrfSign(signTranscript)
+	require.NoError(t, err)
+
+	_, err = pub.VrfVerify(verifyTranscript, inout.Output(), proof)
+	require.True(t, errors.Is(err, errPublicKeyAtInfinity))
 }

--- a/vrf_test.go
+++ b/vrf_test.go
@@ -191,7 +191,8 @@ func TestVrfInOut_MakeBytes(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	bytes := inout.MakeBytes(16, []byte("substrate-babe-vrf"))
+	bytes, err := inout.MakeBytes(16, []byte("substrate-babe-vrf"))
+	require.NoError(t, err)
 	require.Equal(t, make_bytes_16_expected, bytes)
 }
 
@@ -227,6 +228,7 @@ func TestVrfVerify_NotKusama(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	bytes := inout.MakeBytes(16, []byte("substrate-babe-vrf"))
+	bytes, err := inout.MakeBytes(16, []byte("substrate-babe-vrf"))
+	require.NoError(t, err)
 	require.Equal(t, make_bytes_16_expected, bytes)
 }

--- a/vrf_test.go
+++ b/vrf_test.go
@@ -179,7 +179,8 @@ func TestVrfInOut_MakeBytes(t *testing.T) {
 	err = out.Decode(output)
 	require.NoError(t, err)
 
-	inout := out.AttachInput(pubkey, transcript)
+	inout, err := out.AttachInput(pubkey, transcript)
+	require.NoError(t, err)
 	require.Equal(t, input, inout.input.Encode([]byte{}))
 
 	p := new(VrfProof)
@@ -216,7 +217,8 @@ func TestVrfVerify_NotKusama(t *testing.T) {
 	err = out.Decode(output)
 	require.NoError(t, err)
 
-	inout := out.AttachInput(pubkey, transcript)
+	inout, err := out.AttachInput(pubkey, transcript)
+	require.NoError(t, err)
 	require.Equal(t, input, inout.input.Encode([]byte{}))
 
 	p := new(VrfProof)


### PR DESCRIPTION
This PR addresses the issues that were found during the Trail of Bits audit:

- Add checks to the MakeBytes function that returns an error if the size is less than
or equal to zero or if the size is larger than a predetermined value. TOB-CNSF-001
- Add a check to ensure that each random scalar value generated is non-zero.
TOB-CNSF-002
- Add nil pointer checks to all affected functions. TOB-CNSF-004
- Add checks inside the signature and VRF verification functions to reject all inputs
when the public key is the point at infinity. TOB-CNSF-005

The only point that has not been addressed (and likely will not be fixed) is:
- Consider including the base point in the calculation of the challenge scalar.
TOB-CNSF-003

The rust implementers have indicated that this is not needed, as the protocol will never change and the hashing context is included, which is sufficient for our needs. Additionally, it will break cross-compatibility with the rust implemenation and will break backwards-compatibility with the Polkadot protocol.