### PR TITLE
feat: remove `publicKeyAtInfinity` check

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -130,10 +130,6 @@ func (p *PublicKey) Verify(s *Signature, t *merlin.Transcript) (bool, error) {
 		return false, errors.New("transcript provided is nil")
 	}
 
-	if p.key.Equal(publicKeyAtInfinity) == 1 {
-		return false, errPublicKeyAtInfinity
-	}
-
 	t.AppendMessage([]byte("proto-name"), []byte("Schnorr-sig"))
 	pubc := p.Encode()
 	t.AppendMessage([]byte("sign:pk"), pubc[:])

--- a/sign_test.go
+++ b/sign_test.go
@@ -2,7 +2,6 @@ package schnorrkel
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -209,19 +208,4 @@ func TestVerify_rust(t *testing.T) {
 	ok, err := pub.Verify(sig, transcript)
 	require.NoError(t, err)
 	require.True(t, ok)
-}
-
-func TestVerify_PublicKeyAtInfinity(t *testing.T) {
-	transcript := merlin.NewTranscript("hello")
-	priv := SecretKey{}
-	pub, err := priv.Public()
-	require.NoError(t, err)
-	require.Equal(t, pub.key, publicKeyAtInfinity)
-
-	sig, err := priv.Sign(transcript)
-	require.NoError(t, err)
-
-	transcript2 := merlin.NewTranscript("hello")
-	_, err = pub.Verify(sig, transcript2)
-	require.True(t, errors.Is(err, errPublicKeyAtInfinity))
 }


### PR DESCRIPTION
- The rust implementation doesn't have this check
  - https://github.com/w3f/schnorrkel/blob/38035b50f49ecc40e10831bb8c11b59c143b7aa9/src/sign.rs#L230
- This check was impacting the signature verification of block `#8077850` on Westend network
  - Basically, block `#8077850` has an extrinsic in which the public key signer contains all zeroes and this is hitting the `publicKeyAtInfinity` check, removing this check (that doesn't exist in rust version) it passes.